### PR TITLE
Basic Epidisco support

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,11 +4,52 @@ Generate Cohorts based on Epidisco and/or Biokepi results
 ## Example Usage
 
 ```
+from utils.data import load_cohort
 from discohorts import Discohort
-cohort = Discohort(cohort)
-cohort.add_pipeline(name="dna_processing",
-                    ocaml_path="dna_processing.ml",
-                    other_cli_args={"reference-build": "b37decoy",
-                                    "bam-path": lambda patient: patient.tumor_sample.bam_path_dna})
-cohort.run_pipeline("dna_processing")
+
+cohort = load_cohort(min_tumor_mtc=0, min_normal_mtc=0)
+work_dirs = ["/nfs-pool-{}/biokepi/".format(i) for i in range(2, 17)]
+dest_results_dir = "/nfs-pool/biokepi/results"
+cohort = Discohort(
+    cohort,
+    biokepi_work_dirs=work_dirs,
+    dest_results_dir=dest_results_dir)
+
+cohort.add_epidisco_pipeline(
+    pipeline_name="epidisco_1")
+
+# Customize the normal BAM input.
+cohort.add_epidisco_pipeline(
+    pipeline_name="epidisco_2",
+    config=EpidiscoConfig(cohort,
+                          arg_normal_input=lambda patient: patient.tumor_sample.bam_path_dna))
+
+# Customize the normal BAM input and the run name.
+cohort.add_epidisco_pipeline(
+    pipeline_name="epidisco_3",
+    run_name=lambda patient: "epidisco_{}".format(patient.id),
+    config=EpidiscoConfig(cohort,
+                          arg_normal_input=lambda patient: patient.tumor_sample.bam_path_dna))
+
+# Customize the normal BAM input, the run name, and which patients to run on.
+cohort.add_epidisco_pipeline(
+    pipeline_name="epidisco_4",
+    run_name=lambda patient: "epidisco_{}".format(patient.id),
+    config=EpidiscoConfig(cohort,
+                          keep=lambda patient: patient.id == "468",
+                          arg_normal_input=lambda patient: patient.tumor_sample.bam_path_dna))
+
+# Same as #4, but written differently.
+class EpidiscoConfigModified(EpidiscoConfig):
+    def keep(self, patient):
+        return patient.id == "468"
+    def arg_normal_input(self, patient):
+        return patient.tumor_sample.bam_path_dna
+modified_config = EpidiscoConfigModified(cohort)
+cohort.add_epidisco_pipeline(
+    pipeline_name="epidisco_5",
+    config=modified_config)
+
+# This is Discohort's own dry run functionality, FYI. Should have a better name.
+cohort.run_pipeline("epidisco_1", dry_run=True)
 ```

--- a/README.md
+++ b/README.md
@@ -22,14 +22,14 @@ cohort.add_epidisco_pipeline(
 cohort.add_epidisco_pipeline(
     pipeline_name="epidisco_2",
     config=EpidiscoConfig(cohort,
-                          arg_normal_input=lambda patient: patient.tumor_sample.bam_path_dna))
+                          arg_normal_input=lambda patient: patient.normal_sample.bam_path_dna))
 
 # Customize the normal BAM input and the run name.
 cohort.add_epidisco_pipeline(
     pipeline_name="epidisco_3",
     run_name=lambda patient: "epidisco_{}".format(patient.id),
     config=EpidiscoConfig(cohort,
-                          arg_normal_input=lambda patient: patient.tumor_sample.bam_path_dna))
+                          arg_normal_input=lambda patient: patient.normal_sample.bam_path_dna))
 
 # Customize the normal BAM input, the run name, and which patients to run on.
 cohort.add_epidisco_pipeline(
@@ -37,7 +37,7 @@ cohort.add_epidisco_pipeline(
     run_name=lambda patient: "epidisco_{}".format(patient.id),
     config=EpidiscoConfig(cohort,
                           keep=lambda patient: patient.id == "468",
-                          arg_normal_input=lambda patient: patient.tumor_sample.bam_path_dna))
+                          arg_normal_input=lambda patient: patient.normal_sample.bam_path_dna))
 
 # Same as #4, but written differently.
 class EpidiscoConfigModified(EpidiscoConfig):
@@ -49,6 +49,12 @@ modified_config = EpidiscoConfigModified(cohort)
 cohort.add_epidisco_pipeline(
     pipeline_name="epidisco_5",
     config=modified_config)
+    
+# Customize any CLI argument; for example, picard_java_max_heap_size.
+cohort.add_epidisco_pipeline(
+    pipeline_name="epidisco_6",
+    config=EpidiscoConfig(cohort,
+                          arg_picard_java_max_heap_size="20g"))
 
 # This is Discohort's own dry run functionality, FYI. Should have a better name.
 cohort.run_pipeline("epidisco_1", dry_run=True)

--- a/discohorts/__init__.py
+++ b/discohorts/__init__.py
@@ -13,6 +13,7 @@
 # limitations under the License.
 
 from .discohort import Discohort
+from .config import Config, EpidiscoConfig
 
 from ._version import get_versions
 __version__ = get_versions()['version']

--- a/discohorts/config.py
+++ b/discohorts/config.py
@@ -82,10 +82,10 @@ class EpidiscoConfig(Config):
         return True
 
     def arg_with_optitype_rna(self, patient):
-        return self.arg_rna_input(patient)
+        return self.arg_rna_input(patient) is not None
 
     def arg_with_seq2hla(self, patient):
-        return self.arg_rna_input(patient)
+        return self.arg_rna_input(patient) is not None
 
     def arg_with_kallisto(self, patient):
-        return self.arg_rna_input(patient)
+        return self.arg_rna_input(patient) is not None

--- a/discohorts/config.py
+++ b/discohorts/config.py
@@ -1,0 +1,91 @@
+# Copyright (c) 2017. Mount Sinai School of Medicine
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from __future__ import print_function
+from types import FunctionType
+
+
+class Config(object):
+    def __init__(self, discohort, **kwargs):
+        """
+        Override (or create from scratch) any method with either a f(patient)
+        function or a value.
+
+        Any overriding value will be converted into a f(patient) function.
+
+        Any argument to the CLI needs to be prefixed with "arg_".
+        """
+        self.discohort = discohort
+        for key, value in kwargs.items():
+            self.update(key, value)
+
+    def update(self, key, value):
+        if key == "given_work_dir":
+            raise ValueError("Cannot replace given_work_dir in __init__")
+
+        if type(value) == FunctionType:
+            self.__dict__[key] = value
+        else:
+            self.__dict__[key] = lambda patient: value
+
+    def keep(self, patient):
+        return True
+
+    def anonymous_args(self, patient):
+        return []
+
+    def given_work_dir(self, patient, work_dir):
+        # This method is a little special/different. It should not be replaced
+        # in __init__ becauase it isn't of the form f(patient).
+        pass
+
+    def arg_name(self, patient):
+        return None
+
+    def arg_results_path(self, patient):
+        return self.discohort.dest_results_dir
+
+    def arg_reference_build(self, patient):
+        return "b37"
+
+
+class EpidiscoConfig(Config):
+    def arg_normal_input(self, patient):
+        assert patient.normal_sample is not None, "Patient {} has no normal sample".format(patient)
+        return patient.normal_sample.bam_path_dna
+
+    def arg_tumor_input(self, patient):
+        assert patient.tumor_sample is not None, "Patient {} has no tumor sample".format(patient)
+        return patient.tumor_sample.bam_path_dna
+
+    def arg_rna_input(self, patient):
+        assert patient.tumor_sample is not None, "Patient {} has no tumor sample".format(patient)
+        if patient.tumor_sample.bam_path_rna is not None:
+            return patient.tumor_sample.bam_path_rna
+        return None
+
+    def arg_with_optitype_normal(self, patient):
+        return True
+
+    def arg_with_optitype_tumor(self, patient):
+        return True
+
+    def arg_with_optitype_rna(self, patient):
+        return self.arg_rna_input(patient)
+
+    def arg_with_seq2hla(self, patient):
+        return self.arg_rna_input(patient)
+
+    def arg_with_kallisto(self, patient):
+        return self.arg_rna_input(patient)

--- a/discohorts/discohort.py
+++ b/discohorts/discohort.py
@@ -23,6 +23,7 @@ from cohorts import Cohort
 
 from .pipeline import Pipeline
 from .utils import find_files_recursive, find_patient_id
+from .config import EpidiscoConfig
 
 DEFAULT_ID_DELIMS = ["_", "-"]
 
@@ -52,7 +53,11 @@ class Discohort(Cohort):
         self.batch_size = batch_size
         self.batch_wait_secs = batch_wait_secs
 
-    def add_epidisco_pipeline(self, run_name, pipeline_name, config, ocaml_path="run_pipeline.ml"):
+    def add_epidisco_pipeline(self, pipeline_name, config=None, run_name=None, ocaml_path="run_pipeline.ml"):
+        if config is None:
+            config = EpidiscoConfig(self)
+        if run_name is None:
+            run_name = lambda patient: "{}_{}".format(pipeline_name, patient.id)
         config.update("anonymous_args", [run_name])
         return self.add_pipeline(pipeline_name=pipeline_name, config=config, ocaml_path=ocaml_path)
 

--- a/discohorts/discohort.py
+++ b/discohorts/discohort.py
@@ -63,7 +63,7 @@ class Discohort(Cohort):
 
     def add_pipeline(self, pipeline_name, config, ocaml_path):
         if pipeline_name in self.pipelines:
-            raise ValueError("Pipeline already exists: {}".format(name))
+            raise ValueError("Pipeline already exists: {}".format(pipeline_name))
 
         pipeline = Pipeline(
             config=config,
@@ -74,7 +74,7 @@ class Discohort(Cohort):
 
     def run_pipeline(self, pipeline_name, skip_num=0, wait_after_all=False, dry_run=False):
         if pipeline_name not in self.pipelines:
-            raise ValueError("Trying to run a pipeline that does not exist: {}".format(name))
+            raise ValueError("Trying to run a pipeline that does not exist: {}".format(pipeline_name))
 
         pipeline = self.pipelines[pipeline_name]
         pipeline.run(self, skip_num=skip_num, wait_after_all=wait_after_all, dry_run=dry_run)

--- a/discohorts/discohort.py
+++ b/discohorts/discohort.py
@@ -53,21 +53,21 @@ class Discohort(Cohort):
         self.batch_size = batch_size
         self.batch_wait_secs = batch_wait_secs
 
-    def add_epidisco_pipeline(self, pipeline_name, config=None, run_name=None, ocaml_path="run_pipeline.ml"):
+    def add_epidisco_pipeline(self, pipeline_name, config=None, run_name=None, pipeline_path="run_pipeline.ml"):
         if config is None:
             config = EpidiscoConfig(self)
         if run_name is None:
             run_name = lambda patient: "{}_{}".format(pipeline_name, patient.id)
         config.update("anonymous_args", [run_name])
-        return self.add_pipeline(pipeline_name=pipeline_name, config=config, ocaml_path=ocaml_path)
+        return self.add_pipeline(pipeline_name=pipeline_name, config=config, pipeline_path=pipeline_path)
 
-    def add_pipeline(self, pipeline_name, config, ocaml_path):
+    def add_pipeline(self, pipeline_name, config, pipeline_path):
         if pipeline_name in self.pipelines:
             raise ValueError("Pipeline already exists: {}".format(pipeline_name))
 
         pipeline = Pipeline(
             config=config,
-            ocaml_path=ocaml_path,
+            pipeline_path=pipeline_path,
             batch_size=self.batch_size,
             batch_wait_secs=self.batch_wait_secs)
         self.pipelines[pipeline_name] = pipeline

--- a/discohorts/pipeline.py
+++ b/discohorts/pipeline.py
@@ -21,9 +21,9 @@ from types import FunctionType
 
 
 class Pipeline(object):
-    def __init__(self, ocaml_path, config, batch_size, batch_wait_secs):
+    def __init__(self, pipeline_path, config, batch_size, batch_wait_secs):
         self.config = config
-        self.ocaml_path = ocaml_path
+        self.pipeline_path = pipeline_path
         self.batch_size = batch_size
         self.batch_wait_secs = batch_wait_secs
 
@@ -67,7 +67,7 @@ class Pipeline(object):
                 print("Setting BIOKEPI_WORK_DIR={}".format(environ["BIOKEPI_WORK_DIR"]))
 
                 # Build up our command.
-                command = ["ocaml", self.ocaml_path]
+                command = ["ocaml", self.pipeline_path]
 
                 # If an argument has a None value, skip it.
                 # If an argument has a boolean value, include it as --arg if True.

--- a/discohorts/pipeline.py
+++ b/discohorts/pipeline.py
@@ -79,12 +79,17 @@ class Pipeline(object):
                 print("Setting BIOKEPI_WORK_DIR={}".format(
                     environ["BIOKEPI_WORK_DIR"]))
                 command = ["ocaml", self.ocaml_path]
-                command.append("--{}={}".format(
-                    self.name_cli_arg, "{}_{}".format(self.name, patient.id)))
+                command_name = "{}_{}".format(self.name, patient.id)
+                if self.name_cli_arg is not None:
+                    command.append("--{}={}".format(
+                        self.name_cli_arg, command_name))
                 for cli_arg, cli_arg_value in self.other_cli_args.items():
                     if type(cli_arg_value) == FunctionType:
                         cli_arg_value = cli_arg_value(patient)
                     command.append("--{}={}".format(cli_arg, cli_arg_value))
+                # No name CLI arg? Append the name to the end of the command
+                if self.name_cli_arg is None:
+                    command.append(command_name)
                 print("Running {}".format(" ".join(command)))
                 ran_count += 1
 

--- a/discohorts/pipeline.py
+++ b/discohorts/pipeline.py
@@ -14,21 +14,16 @@
 
 from __future__ import print_function
 
-from types import FunctionType
 from subprocess import check_call
 from os import environ, path
 import time
+from types import FunctionType
+
 
 class Pipeline(object):
-    def __init__(self, name, ocaml_path, name_cli_arg, other_cli_args,
-                 patient_subset_function, work_dir_function,
-                 batch_size, batch_wait_secs):
-        self.name = name
+    def __init__(self, ocaml_path, config, batch_size, batch_wait_secs):
+        self.config = config
         self.ocaml_path = ocaml_path
-        self.name_cli_arg = name_cli_arg
-        self.other_cli_args = other_cli_args
-        self.patient_subset_function = patient_subset_function
-        self.work_dir_function = work_dir_function
         self.batch_size = batch_size
         self.batch_wait_secs = batch_wait_secs
 
@@ -38,28 +33,18 @@ class Pipeline(object):
         original_install_tools_path = environ.get("INSTALL_TOOLS_PATH", None)
         original_pyensembl_cache_dir = environ.get("PYENSEMBL_CACHE_DIR", None)
         try:
-            environ["INSTALL_TOOLS_PATH"] = path.join(original_work_dir,
-                                                      "toolkit")
-            print("Setting INSTALL_TOOLS_PATH={}".format(
-                environ["INSTALL_TOOLS_PATH"]))
-            environ["PYENSEMBL_CACHE_DIR"] = path.join(original_work_dir,
-                                                       "pyensembl-cache")
-            print("Setting PYENSEMBL_CACHE_DIR={}".format(
-                environ["PYENSEMBL_CACHE_DIR"]))
-            environ["REFERENCE_GENOME_PATH"] = path.join(original_work_dir,
-                                                         "reference-genome")
-            print("Setting REFERENCE_GENOME_PATH={}".format(
-                environ["REFERENCE_GENOME_PATH"]))
+            environ["INSTALL_TOOLS_PATH"] = path.join(original_work_dir, "toolkit")
+            print("Setting INSTALL_TOOLS_PATH={}".format(environ["INSTALL_TOOLS_PATH"]))
+            environ["PYENSEMBL_CACHE_DIR"] = path.join(original_work_dir, "pyensembl-cache")
+            print("Setting PYENSEMBL_CACHE_DIR={}".format(environ["PYENSEMBL_CACHE_DIR"]))
+            environ["REFERENCE_GENOME_PATH"] = path.join(original_work_dir, "reference-genome")
+            print("Setting REFERENCE_GENOME_PATH={}".format(environ["REFERENCE_GENOME_PATH"]))
             work_dir_index = 0
 
-            if self.patient_subset_function is None:
-                patient_subset = discohort
-            else:
-                patient_subset = [
-                    patient for patient in discohort
-                    if self.patient_subset_function(patient)
-                ]
+            # Run on only the correct subset of patients.
+            patient_subset = [patient for patient in discohort if self.config.keep(patient)]
 
+            # Map from patient to the appropriate work dir.
             def get_patient_to_work_dir(patients, work_dirs):
                 num_chunks = len(work_dirs)
                 return_dict = {}
@@ -68,28 +53,43 @@ class Pipeline(object):
                         return_dict[item] = work_dir
                 return return_dict
 
-            patient_to_work_dir = get_patient_to_work_dir(
-                patient_subset, discohort.biokepi_work_dirs)
-            print("Running on a patient subset of {} patients".format(
-                len(patient_subset)))
+            patient_to_work_dir = get_patient_to_work_dir(patient_subset,
+                                                          discohort.biokepi_work_dirs)
+
+            # Loop over all relevant patients.
+            print("Running on a patient subset of {} patients".format(len(patient_subset)))
             for patient in patient_subset:
-                if self.work_dir_function is not None:
-                    self.work_dir_function(patient_to_work_dir[patient])
+                # Grab the work_dir and run an optional function that takes in work_dir as input.
+                # Also set the BIOKEPI_WORK_DIR environment variable.
+                work_dir = patient_to_work_dir[patient]
+                self.config.given_work_dir(patient, work_dir)
                 environ["BIOKEPI_WORK_DIR"] = patient_to_work_dir[patient]
-                print("Setting BIOKEPI_WORK_DIR={}".format(
-                    environ["BIOKEPI_WORK_DIR"]))
+                print("Setting BIOKEPI_WORK_DIR={}".format(environ["BIOKEPI_WORK_DIR"]))
+
+                # Build up our command.
                 command = ["ocaml", self.ocaml_path]
-                command_name = "{}_{}".format(self.name, patient.id)
-                if self.name_cli_arg is not None:
-                    command.append("--{}={}".format(
-                        self.name_cli_arg, command_name))
-                for cli_arg, cli_arg_value in self.other_cli_args.items():
-                    if type(cli_arg_value) == FunctionType:
-                        cli_arg_value = cli_arg_value(patient)
-                    command.append("--{}={}".format(cli_arg, cli_arg_value))
-                # No name CLI arg? Append the name to the end of the command
-                if self.name_cli_arg is None:
-                    command.append(command_name)
+
+                # If an argument has a None value, skip it.
+                # If an argument has a boolean value, include it as --arg if True.
+                # If an argument has a non-boolean value, include it as --arg=<value>.
+                for attr in dir(self.config):
+                    if attr.startswith("arg_"):
+                        value = getattr(self.config, attr)
+                        value = value(patient) # Always will be f(patient)
+                        if value is not None:
+                            arg_name = attr.split("arg_")[1]
+                            arg_name = arg_name.replace("_", "-")
+                            if value == True:
+                                command.append("--{}".format(arg_name))
+                            elif type(value) != bool:
+                                command.append("--{}={}".format(arg_name, value))
+
+                # Anonymous args (non-keyword args) have no key/value.
+                for anon_arg in self.config.anonymous_args(patient):
+                    if type(anon_arg) == FunctionType:
+                        anon_arg = anon_arg(patient)
+                    command.append(anon_arg)
+
                 print("Running {}".format(" ".join(command)))
                 ran_count += 1
 
@@ -102,13 +102,15 @@ class Pipeline(object):
                         check_call(command)
 
                 if ran_count % self.batch_size == 0:
-                    print("Waiting for {} seconds after the last batch of {} ({} total submitted so far)".format(
-                        self.batch_wait_secs, self.batch_size, ran_count))
+                    print(
+                        "Waiting for {} seconds after the last batch of {} ({} total submitted so far)".
+                        format(self.batch_wait_secs, self.batch_size, ran_count))
                     time.sleep(self.batch_wait_secs)
 
                 if wait_after_all and ran_count == len(patient_subset):
-                    print("Waiting for {} seconds after the cohort ended ({} total submitted so far)".format(
-                        self.batch_wait_secs, ran_count))
+                    print(
+                        "Waiting for {} seconds after the cohort ended ({} total submitted so far)".
+                        format(self.batch_wait_secs, ran_count))
         finally:
             environ["BIOKEPI_WORK_DIR"] = original_work_dir
             if original_install_tools_path:


### PR DESCRIPTION
In this PR, add `add_epidisco_pipeline` to allow users to use Epidisco in a more straightforward way from Discohorts. (And some minor spacing changes; sorry for the confusion there.)

In serious need of documentation and testing, but I wanted to get this out there before the next Epidisco run over a cohort. cc @armish @jburos 

Example usage with various options:

```
from utils.data import load_cohort
from discohorts import Discohort

cohort = load_cohort(min_tumor_mtc=0, min_normal_mtc=0)
work_dirs = ["/nfs-pool-{}/biokepi/".format(i) for i in range(2, 17)]
dest_results_dir = "/nfs-pool/biokepi/results"
cohort = Discohort(
    cohort,
    biokepi_work_dirs=work_dirs,
    biokepi_results_dirs=[], # Ignore for now; to be removed in another PR
    dest_results_dir=dest_results_dir)

cohort.add_epidisco_pipeline(
    pipeline_name="epidisco_1")

# Customize the normal BAM input.
cohort.add_epidisco_pipeline(
    pipeline_name="epidisco_2",
    config=EpidiscoConfig(cohort,
                          arg_normal_input=lambda patient: patient.tumor_sample.bam_path_dna))

# Customize the normal BAM input and the run name.
cohort.add_epidisco_pipeline(
    pipeline_name="epidisco_3",
    run_name=lambda patient: "epidisco_{}".format(patient.id),
    config=EpidiscoConfig(cohort,
                          arg_normal_input=lambda patient: patient.tumor_sample.bam_path_dna))

# Customize the normal BAM input, the run name, and which patients to run on.
cohort.add_epidisco_pipeline(
    pipeline_name="epidisco_4",
    run_name=lambda patient: "epidisco_{}".format(patient.id),
    config=EpidiscoConfig(cohort,
                          keep=lambda patient: patient.id == "468",
                          arg_normal_input=lambda patient: patient.tumor_sample.bam_path_dna))

# Same as #4, but written differently.
class EpidiscoConfigModified(EpidiscoConfig):
    def keep(self, patient):
        return patient.id == "468"
    def arg_normal_input(self, patient):
        return patient.tumor_sample.bam_path_dna
modified_config = EpidiscoConfigModified(cohort)
cohort.add_epidisco_pipeline(
    pipeline_name="epidisco_5",
    config=modified_config)

# This is Discohort's own dry run functionality, FYI. Should have a better name.
cohort.run_pipeline("epidisco_1", dry_run=True)
```

It will round robin over the specified NFS servers/work dirs. Batching/wait times and such can be configured in the `run(...)` function.