### PR TITLE
Remove deepcopy and making Config.discohort optional

### DIFF
--- a/discohorts/config.py
+++ b/discohorts/config.py
@@ -17,7 +17,7 @@ from types import FunctionType
 
 
 class Config(object):
-    def __init__(self, discohort, **kwargs):
+    def __init__(self, discohort=None, **kwargs):
         """
         Override (or create from scratch) any method with either a f(patient)
         function or a value.
@@ -25,6 +25,8 @@ class Config(object):
         Any overriding value will be converted into a f(patient) function.
 
         Any argument to the CLI needs to be prefixed with "arg_".
+
+        If Discohort is None, the user is expected to provide it later.
         """
         self.discohort = discohort
         for key, value in kwargs.items():
@@ -54,6 +56,9 @@ class Config(object):
         return None
 
     def arg_results_path(self, patient):
+        if self.discohort is None:
+            raise ValueError("Config requires a self.discohort value.")
+
         # If we have a single result directory, use that.
         if len(self.discohort.biokepi_results_dirs) == 1:
             return self.discohort.biokepi_results_dirs[0]

--- a/discohorts/discohort.py
+++ b/discohorts/discohort.py
@@ -14,7 +14,7 @@
 
 from __future__ import print_function
 
-from copy import deepcopy
+from copy import copy
 from os import path, listdir, makedirs
 from shutil import copy2, move
 from collections import defaultdict
@@ -44,7 +44,8 @@ class Discohort(Cohort):
 
         self.__class__ = type(base_object.__class__.__name__, (self.__class__,
                                                                base_object.__class__), {})
-        self.__dict__ = deepcopy(base_object.__dict__)
+        self.__dict__ = copy(base_object.__dict__)
+
         self.pipelines = {}
         self.is_processed = False
         self.biokepi_work_dirs = biokepi_work_dirs
@@ -69,6 +70,9 @@ class Discohort(Cohort):
     def add_pipeline(self, pipeline_name, config, pipeline_path):
         if pipeline_name in self.pipelines:
             raise ValueError("Pipeline already exists: {}".format(pipeline_name))
+
+        if config.discohort is None:
+            config.discohort = self
 
         pipeline = Pipeline(
             config=config,


### PR DESCRIPTION
In this PR:

* Remove `deepcopy` to fix this weird bug: https://github.com/hammerlab/discohorts/issues/12
* Make `Config.discohort` optional, to remove an unnecessary line from e.g.:

```
cohort.add_pipeline(
    pipeline_name="rna_processing",
    pipeline_path="rna_processing.ml",
    config=Config(
        discohort=cohort, # <-- We can now remove this line
        arg_name=lambda patient: "rna_processing_{}".format(patient.id)))
```
